### PR TITLE
docs: 优化中英文档跳转链接显示

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
     <img src="https://img.shields.io/badge/Neovim-%E2%89%A50.10-57A143?style=for-the-badge&logo=neovim&logoColor=white&labelColor=302D41"  alt="Neovim Logo"/>
 </p></div>
 
-🌍 [English](./README_EN.md) | [简体中文](./README.md)
+🌍 简体中文 | [English](./README_EN.md)
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -28,6 +28,6 @@
     <img src="https://img.shields.io/badge/Neovim-%E2%89%A50.10-57A143?style=for-the-badge&logo=neovim&logoColor=white&labelColor=302D41"  alt="Neovim Logo"/>
 </p></div>
 
-🌍 [English](./README_EN.md) | [简体中文](./README.md)
+🌍 [简体中文](./README.md) | English 
 
 ---


### PR DESCRIPTION
我看开源项目文档不同语言之间跳转，当前所在语言文档都不加重复的链接显示